### PR TITLE
Enable workflow dispatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,7 @@ on:
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch: # Allow manual triggering.
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
Follow  [the guide](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch) to enable manually triggering to Docker.

In general, because changes to this repo will be very infrequent, it's likely the publish workflow will be disabled, and I'll forget to re-enable before merges.